### PR TITLE
Fixing format regex

### DIFF
--- a/app/chatbot.rb
+++ b/app/chatbot.rb
@@ -131,7 +131,7 @@ class Chatbot
           # don't bother understanding the next line, it just takes the data PS sends for formats and
           # changes it into a list of formats
           
-          $battle_formats = ('|' + data.gsub(/[,#]/, '')).gsub(/\|\d\|[^|]+\|/, '').split('|').map { |f| CBUtils.condense_name(f) }
+          $battle_formats = ('|' + data.gsub(/[,#]/, '')).gsub(/\|\d\|[^|]+/, '').split('|').map { |f| CBUtils.condense_name(f) }
         when 'updateuser'
           if CBUtils.condense_name(message[2]) == CBUtils.condense_name(@name)
             puts "#{@id}: Succesfully logged in!"


### PR DESCRIPTION
Removing the last `|` causes some formats to be concatenated accidentally
